### PR TITLE
Add version-field to manifest.json

### DIFF
--- a/custom_components/cellar_tracker/manifest.json
+++ b/custom_components/cellar_tracker/manifest.json
@@ -3,6 +3,7 @@
   "name": "Cellar Tracker",
   "documentation": "https://github.com/ahoernecke/ha_cellar_tracker",
   "dependencies": [],
+  "version": "20210413",
   "codeowners": ["@ahoernecke"],
   "requirements": ["cellartracker"]
 }


### PR DESCRIPTION
No 'version' key in the manifest file for custom integration 'cellar_tracker'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'cellar_tracker'