### PR TITLE
Replace deprecated function for state_attributes

### DIFF
--- a/custom_components/cellar_tracker/sensor.py
+++ b/custom_components/cellar_tracker/sensor.py
@@ -67,7 +67,7 @@ class WineCellarSensor(Entity):
 
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         if(self._sub_type):
             return self._data
 


### PR DESCRIPTION
Entity.device_state_attributes has been deprecated since 2021.04.
With 2021.12 a warning has been added which is spamming my logs.

Update to use Entity.extra_state_attributes instead.